### PR TITLE
thunderbird-nightly-bin: Add group policy to disable app updates

### DIFF
--- a/thunderbird-nightly-bin/.SRCINFO
+++ b/thunderbird-nightly-bin/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = thunderbird-nightly-bin
 	pkgdesc = Standalone Mail/News reader - Nightly build
-	pkgver = 79.0a1.20200611
-	pkgrel = 2
+	pkgver = 79.0a1.20200615
+	pkgrel = 1
 	url = https://www.mozilla.org/thunderbird
 	install = thunderbird-nightly.install
 	arch = i686
@@ -38,10 +38,12 @@ pkgbase = thunderbird-nightly-bin
 	source = https://download-installer.cdn.mozilla.net/pub/thunderbird/nightly/latest-comm-central/thunderbird-79.0a1.en-US.linux-x86_64.tar.bz2
 	source = thunderbird-nightly.desktop
 	source = vendor.js
+	source = policies.json
 	b2sums = SKIP
 	b2sums = SKIP
 	b2sums = 1f954c9a23842367be37c1f56b853de6a336c1b4156df42f88b14f1614d194c2f996f1cc589cdbfcea398bb9cedcd527ef3c6fb8b01e2f07c46290043e24c6b7
 	b2sums = 674d1ee883e675c37b0af0ac97c339a8c0f2b53cb06e64db64aaa3f22f83d7179b6fa3e122344f3413ccb9956776288db9bc608b5cedef640cbd223838be7476
+	b2sums = f8df63721191d84d8f1ceec263f63c44fd5dadeae0939baf9a4a6b1852516722b2a3d94b8d403cc7b6c6b525d5236f357ab65a72d716aab1f5bef47800b5a18c
 
 pkgname = thunderbird-nightly-bin
 

--- a/thunderbird-nightly-bin/PKGBUILD
+++ b/thunderbird-nightly-bin/PKGBUILD
@@ -4,9 +4,9 @@
 # Based on [extra]'s thunderbird
 
 pkgname=thunderbird-nightly-bin
-pkgver=79.0a1.20200611
+pkgver=79.0a1.20200615
 _version=79.0a1
-pkgrel=2
+pkgrel=1
 pkgdesc='Standalone Mail/News reader - Nightly build'
 arch=('i686' 'x86_64')
 url="https://www.mozilla.org/thunderbird"
@@ -26,12 +26,14 @@ FX_SRC_URI="https://download-installer.cdn.mozilla.net/pub/thunderbird/nightly/l
 source=("${FX_SRC_URI}.txt"
         "${FX_SRC_URI}.tar.bz2"
         "${pkgname%-bin}.desktop"
-        "vendor.js")
+        "vendor.js"
+        "policies.json")
 
 b2sums=('SKIP'
         'SKIP'
         '1f954c9a23842367be37c1f56b853de6a336c1b4156df42f88b14f1614d194c2f996f1cc589cdbfcea398bb9cedcd527ef3c6fb8b01e2f07c46290043e24c6b7'
-        '674d1ee883e675c37b0af0ac97c339a8c0f2b53cb06e64db64aaa3f22f83d7179b6fa3e122344f3413ccb9956776288db9bc608b5cedef640cbd223838be7476')
+        '674d1ee883e675c37b0af0ac97c339a8c0f2b53cb06e64db64aaa3f22f83d7179b6fa3e122344f3413ccb9956776288db9bc608b5cedef640cbd223838be7476'
+        'f8df63721191d84d8f1ceec263f63c44fd5dadeae0939baf9a4a6b1852516722b2a3d94b8d403cc7b6c6b525d5236f357ab65a72d716aab1f5bef47800b5a18c')
 
 pkgver(){
   echo "${_version}.$(head -n1 "${FX_SRC}.txt" |cut -c -8)"
@@ -41,6 +43,7 @@ package() {
   install -d "${pkgdir}"/{usr/bin,opt}
   cp -a thunderbird "${pkgdir}"/opt/${pkgname%-bin}-${pkgver}
   cp vendor.js "${pkgdir}"/opt/${pkgname%-bin}-${pkgver}/defaults/pref/
+  install -Dm644 policies.json -t "$pkgdir/opt/${pkgname%-bin}-${pkgver}/distribution"
   ln -s /opt/${pkgname%-bin}-${pkgver}/thunderbird "${pkgdir}"/usr/bin/${pkgname%-bin}
   for i in 16x16 32x32 48x48 64x64 128x128; do
       install -Dm644 thunderbird/chrome/icons/default/default${i/x*/}.png "${pkgdir}"/usr/share/icons/hicolor/${i}/apps/${pkgname%-bin}.png

--- a/thunderbird-nightly-bin/policies.json
+++ b/thunderbird-nightly-bin/policies.json
@@ -1,0 +1,5 @@
+{
+  "policies": {
+    "DisableAppUpdate": true
+  }
+}


### PR DESCRIPTION
As per the suggestion of bmd_online and blackout on the aur, disable thunderbirds update notifications.