### PR TITLE
Fix onivim2 and onivim2-git build

### DIFF
--- a/onivim2-git/.SRCINFO
+++ b/onivim2-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = onivim2-git
 	pkgdesc = Native, lightweight modal code editor
-	pkgver = 1527.b6e238811
+	pkgver = 1775.8a1739ec0
 	pkgrel = 1
 	url = https://github.com/onivim/oni2
 	install = onivim2.install

--- a/onivim2-git/PKGBUILD
+++ b/onivim2-git/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: Frederick Gnodtke <frederick@gnodtke.net>
 
 pkgname=onivim2-git
-pkgver=1527.b6e238811
+pkgver=1775.8a1739ec0
 pkgrel=1
 pkgdesc='Native, lightweight modal code editor'
 arch=('any')

--- a/onivim2-git/PKGBUILD
+++ b/onivim2-git/PKGBUILD
@@ -29,10 +29,10 @@ pkgver() {
 build() {
   cd ${pkgname}
   export ESY__PREFIX="${srcdir}"/esy_cache
+  node install-node-deps.js
   esy install
   esy bootstrap
   esy build
-  node install-node-deps.js
   esy '@release' install
   esy '@release' run -f --checkhealth
   esy '@release' create

--- a/onivim2/.SRCINFO
+++ b/onivim2/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = onivim2
 	pkgdesc = Native, lightweight modal code editor
 	pkgver = 0.5.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/onivim/oni2
 	install = onivim2.install
 	arch = any

--- a/onivim2/PKGBUILD
+++ b/onivim2/PKGBUILD
@@ -4,7 +4,7 @@
 pkgname=onivim2
 pkgver=0.5.0
 _commit=c6b7772e18696ac033a4ec3d0e19e6fa4e0249b5
-pkgrel=1
+pkgrel=2
 pkgdesc='Native, lightweight modal code editor'
 arch=('any')
 url='https://github.com/onivim/oni2'

--- a/onivim2/PKGBUILD
+++ b/onivim2/PKGBUILD
@@ -23,10 +23,10 @@ b2sums=('SKIP'
 build() {
   cd ${pkgname}
   export ESY__PREFIX="${srcdir}"/esy_cache
+  node install-node-deps.js
   esy install
   esy bootstrap
   esy build
-  node install-node-deps.js
   esy x Oni2 -f --checkhealth
   esy create-release
 }


### PR DESCRIPTION
Hi, the reason I make this PR because I cannot build the onivim2 or onivim2-git package, the package build step fails. As usual, somebody tried to fix it and pointed out on https://aur.archlinux.org/packages/onivim2-git/#comment-783465 comment to run the node install before esy build and I tried to do that, it works :smile:.